### PR TITLE
removing web root route, printing api doc url on api root

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -19,7 +19,7 @@ use App\Http\Controllers\AuthController;
 
 Route::get(
     '/', function () {
-        return 'https://app.swaggerhub.com/apis-docs/pbbg/api.pbbg.com/0.1.0';
+        return 'https://app.swaggerhub.com/apis-docs/pbbg/api.pbbg.com';
     }
 );
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -19,8 +19,8 @@ use App\Http\Controllers\AuthController;
 
 Route::get(
     '/', function () {
-    return 'https://app.swaggerhub.com/apis/pbbg/api.pbbg.com/0.1.0';
-}
+        return 'https://app.swaggerhub.com/apis-docs/pbbg/api.pbbg.com/0.1.0';
+    }
 );
 
 Route::post('register', [AuthController::class, 'register']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -17,6 +17,12 @@ use App\Http\Controllers\AuthController;
 |
 */
 
+Route::get(
+    '/', function () {
+    return 'https://app.swaggerhub.com/apis/pbbg/api.pbbg.com/0.1.0';
+}
+);
+
 Route::post('register', [AuthController::class, 'register']);
 Route::post('login', [AuthController::class, 'login']);
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,9 +12,3 @@ use Illuminate\Support\Facades\Route;
 | contains the "web" middleware group. Now create something great!
 |
 */
-
-Route::get(
-    '/', function () {
-        return view('welcome');
-    }
-);


### PR DESCRIPTION
I've got initial docs on swagger hub.  I'd like to self-host them eventually, but that's looking a little more involved than we need right now.

This change will just point the api root to our swagger hub url for now.