### PR TITLE
Add administrator role

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -62,5 +62,8 @@ class Kernel extends HttpKernel
         'signed' => \Illuminate\Routing\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+        'role' => \Spatie\Permission\Middlewares\RoleMiddleware::class,
+        'permission' => \Spatie\Permission\Middlewares\PermissionMiddleware::class,
+        'role_or_permission' => \Spatie\Permission\Middlewares\RoleOrPermissionMiddleware::class,
     ];
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -8,11 +8,15 @@ use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Passport\HasApiTokens;
 use Laravel\Scout\Searchable;
+use Spatie\Permission\Traits\HasPermissions;
+use Spatie\Permission\Traits\HasRoles;
 
 class User extends Authenticatable
 {
     use HasApiTokens;
     use HasFactory;
+    use HasPermissions;
+    use HasRoles;
     use Notifiable;
     use Searchable;
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "laravel/passport": "^10.0",
         "laravel/scout": "^8.3",
         "laravel/tinker": "^2.0",
-        "opis/json-schema": "^1.0"
+        "opis/json-schema": "^1.0",
+        "spatie/laravel-permission": "^3.17"
     },
     "require-dev": {
         "facade/ignition": "^2.3.6",

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "laravel/scout": "^8.3",
         "laravel/tinker": "^2.0",
         "opis/json-schema": "^1.0",
+        "spatie/laravel-permission": "^3.17",
         "willvincent/feeds": "^2.2"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c2edf6a36aac6d00e4c6814973d35925",
+    "content-hash": "17b4f3b92b29069f9105f7ded6f8ab76",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",
@@ -3116,6 +3116,84 @@
                 }
             ],
             "time": "2020-08-18T17:17:46+00:00"
+        },
+        {
+            "name": "spatie/laravel-permission",
+            "version": "3.17.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-permission.git",
+                "reference": "35d40a45e49f5713f477823b571e05ef6a3a0394"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-permission/zipball/35d40a45e49f5713f477823b571e05ef6a3a0394",
+                "reference": "35d40a45e49f5713f477823b571e05ef6a3a0394",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/auth": "^5.8|^6.0|^7.0|^8.0",
+                "illuminate/container": "^5.8|^6.0|^7.0|^8.0",
+                "illuminate/contracts": "^5.8|^6.0|^7.0|^8.0",
+                "illuminate/database": "^5.8|^6.0|^7.0|^8.0",
+                "php": "^7.2.5"
+            },
+            "require-dev": {
+                "orchestra/testbench": "^3.8|^4.0|^5.0|^6.0",
+                "phpunit/phpunit": "^8.0|^9.0",
+                "predis/predis": "^1.1"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Spatie\\Permission\\PermissionServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\Permission\\": "src"
+                },
+                "files": [
+                    "src/helpers.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Permission handling for Laravel 5.8 and up",
+            "homepage": "https://github.com/spatie/laravel-permission",
+            "keywords": [
+                "acl",
+                "laravel",
+                "permission",
+                "permissions",
+                "rbac",
+                "roles",
+                "security",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/laravel-permission/issues",
+                "source": "https://github.com/spatie/laravel-permission/tree/3.17.0"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                }
+            ],
+            "time": "2020-09-16T16:47:18+00:00"
         },
         {
             "name": "swiftmailer/swiftmailer",
@@ -8351,5 +8429,5 @@
         "php": "^7.3"
     },
     "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "84d195fc5e46388c4ed78247bbbb5764",
+    "content-hash": "c7559d11b38141bf16cdcce566217cd3",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",
@@ -3183,6 +3183,84 @@
                 "rss"
             ],
             "time": "2020-10-14T07:17:22+00:00"
+        },
+        {
+            "name": "spatie/laravel-permission",
+            "version": "3.17.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-permission.git",
+                "reference": "35d40a45e49f5713f477823b571e05ef6a3a0394"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-permission/zipball/35d40a45e49f5713f477823b571e05ef6a3a0394",
+                "reference": "35d40a45e49f5713f477823b571e05ef6a3a0394",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/auth": "^5.8|^6.0|^7.0|^8.0",
+                "illuminate/container": "^5.8|^6.0|^7.0|^8.0",
+                "illuminate/contracts": "^5.8|^6.0|^7.0|^8.0",
+                "illuminate/database": "^5.8|^6.0|^7.0|^8.0",
+                "php": "^7.2.5"
+            },
+            "require-dev": {
+                "orchestra/testbench": "^3.8|^4.0|^5.0|^6.0",
+                "phpunit/phpunit": "^8.0|^9.0",
+                "predis/predis": "^1.1"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Spatie\\Permission\\PermissionServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\Permission\\": "src"
+                },
+                "files": [
+                    "src/helpers.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Permission handling for Laravel 5.8 and up",
+            "homepage": "https://github.com/spatie/laravel-permission",
+            "keywords": [
+                "acl",
+                "laravel",
+                "permission",
+                "permissions",
+                "rbac",
+                "roles",
+                "security",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/laravel-permission/issues",
+                "source": "https://github.com/spatie/laravel-permission/tree/3.17.0"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                }
+            ],
+            "time": "2020-09-16T16:47:18+00:00"
         },
         {
             "name": "swiftmailer/swiftmailer",
@@ -8469,5 +8547,5 @@
     "platform-dev": {
         "ext-json": "*"
     },
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/config/permission.php
+++ b/config/permission.php
@@ -1,0 +1,143 @@
+<?php
+
+return [
+
+    'models' => [
+
+        /*
+         * When using the "HasPermissions" trait from this package, we need to know which
+         * Eloquent model should be used to retrieve your permissions. Of course, it
+         * is often just the "Permission" model but you may use whatever you like.
+         *
+         * The model you want to use as a Permission model needs to implement the
+         * `Spatie\Permission\Contracts\Permission` contract.
+         */
+
+        'permission' => Spatie\Permission\Models\Permission::class,
+
+        /*
+         * When using the "HasRoles" trait from this package, we need to know which
+         * Eloquent model should be used to retrieve your roles. Of course, it
+         * is often just the "Role" model but you may use whatever you like.
+         *
+         * The model you want to use as a Role model needs to implement the
+         * `Spatie\Permission\Contracts\Role` contract.
+         */
+
+        'role' => Spatie\Permission\Models\Role::class,
+
+    ],
+
+    'table_names' => [
+
+        /*
+         * When using the "HasRoles" trait from this package, we need to know which
+         * table should be used to retrieve your roles. We have chosen a basic
+         * default value but you may easily change it to any table you like.
+         */
+
+        'roles' => 'roles',
+
+        /*
+         * When using the "HasPermissions" trait from this package, we need to know which
+         * table should be used to retrieve your permissions. We have chosen a basic
+         * default value but you may easily change it to any table you like.
+         */
+
+        'permissions' => 'permissions',
+
+        /*
+         * When using the "HasPermissions" trait from this package, we need to know which
+         * table should be used to retrieve your models permissions. We have chosen a
+         * basic default value but you may easily change it to any table you like.
+         */
+
+        'model_has_permissions' => 'model_has_permissions',
+
+        /*
+         * When using the "HasRoles" trait from this package, we need to know which
+         * table should be used to retrieve your models roles. We have chosen a
+         * basic default value but you may easily change it to any table you like.
+         */
+
+        'model_has_roles' => 'model_has_roles',
+
+        /*
+         * When using the "HasRoles" trait from this package, we need to know which
+         * table should be used to retrieve your roles permissions. We have chosen a
+         * basic default value but you may easily change it to any table you like.
+         */
+
+        'role_has_permissions' => 'role_has_permissions',
+    ],
+
+    'column_names' => [
+
+        /*
+         * Change this if you want to name the related model primary key other than
+         * `model_id`.
+         *
+         * For example, this would be nice if your primary keys are all UUIDs. In
+         * that case, name this `model_uuid`.
+         */
+
+        'model_morph_key' => 'model_id',
+    ],
+
+    /*
+     * When set to true, the required permission names are added to the exception
+     * message. This could be considered an information leak in some contexts, so
+     * the default setting is false here for optimum safety.
+     */
+
+    'display_permission_in_exception' => false,
+
+    /*
+     * When set to true, the required role names are added to the exception
+     * message. This could be considered an information leak in some contexts, so
+     * the default setting is false here for optimum safety.
+     */
+
+    'display_role_in_exception' => false,
+
+    /*
+     * By default wildcard permission lookups are disabled.
+     */
+
+    'enable_wildcard_permission' => false,
+
+    'cache' => [
+
+        /*
+         * By default all permissions are cached for 24 hours to speed up performance.
+         * When permissions or roles are updated the cache is flushed automatically.
+         */
+
+        'expiration_time' => \DateInterval::createFromDateString('24 hours'),
+
+        /*
+         * The cache key used to store all permissions.
+         */
+
+        'key' => 'spatie.permission.cache',
+
+        /*
+         * When checking for a permission against a model by passing a Permission
+         * instance to the check, this key determines what attribute on the
+         * Permissions model is used to cache against.
+         *
+         * Ideally, this should match your preferred way of checking permissions, eg:
+         * `$user->can('view-posts')` would be 'name'.
+         */
+
+        'model_key' => 'name',
+
+        /*
+         * You may optionally indicate a specific cache driver to use for permission and
+         * role caching using any of the `store` drivers listed in the cache.php config
+         * file. Using 'default' here means to use the `default` set in cache.php.
+         */
+
+        'store' => 'default',
+    ],
+];

--- a/database/migrations/2020_10_28_095606_create_permission_tables.php
+++ b/database/migrations/2020_10_28_095606_create_permission_tables.php
@@ -1,0 +1,110 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreatePermissionTables extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $tableNames = config('permission.table_names');
+        $columnNames = config('permission.column_names');
+
+        if (empty($tableNames)) {
+            throw new \Exception('Error: config/permission.php not loaded. Run [php artisan config:clear] and try again.');
+        }
+
+        Schema::create($tableNames['permissions'], function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name');
+            $table->string('guard_name');
+            $table->timestamps();
+        });
+
+        Schema::create($tableNames['roles'], function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name');
+            $table->string('guard_name');
+            $table->timestamps();
+        });
+
+        Schema::create($tableNames['model_has_permissions'], function (Blueprint $table) use ($tableNames, $columnNames) {
+            $table->unsignedBigInteger('permission_id');
+
+            $table->string('model_type');
+            $table->unsignedBigInteger($columnNames['model_morph_key']);
+            $table->index([$columnNames['model_morph_key'], 'model_type'], 'model_has_permissions_model_id_model_type_index');
+
+            $table->foreign('permission_id')
+                ->references('id')
+                ->on($tableNames['permissions'])
+                ->onDelete('cascade');
+
+            $table->primary(['permission_id', $columnNames['model_morph_key'], 'model_type'],
+                    'model_has_permissions_permission_model_type_primary');
+        });
+
+        Schema::create($tableNames['model_has_roles'], function (Blueprint $table) use ($tableNames, $columnNames) {
+            $table->unsignedBigInteger('role_id');
+
+            $table->string('model_type');
+            $table->unsignedBigInteger($columnNames['model_morph_key']);
+            $table->index([$columnNames['model_morph_key'], 'model_type'], 'model_has_roles_model_id_model_type_index');
+
+            $table->foreign('role_id')
+                ->references('id')
+                ->on($tableNames['roles'])
+                ->onDelete('cascade');
+
+            $table->primary(['role_id', $columnNames['model_morph_key'], 'model_type'],
+                    'model_has_roles_role_model_type_primary');
+        });
+
+        Schema::create($tableNames['role_has_permissions'], function (Blueprint $table) use ($tableNames) {
+            $table->unsignedBigInteger('permission_id');
+            $table->unsignedBigInteger('role_id');
+
+            $table->foreign('permission_id')
+                ->references('id')
+                ->on($tableNames['permissions'])
+                ->onDelete('cascade');
+
+            $table->foreign('role_id')
+                ->references('id')
+                ->on($tableNames['roles'])
+                ->onDelete('cascade');
+
+            $table->primary(['permission_id', 'role_id'], 'role_has_permissions_permission_id_role_id_primary');
+        });
+
+        app('cache')
+            ->store(config('permission.cache.store') != 'default' ? config('permission.cache.store') : null)
+            ->forget(config('permission.cache.key'));
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $tableNames = config('permission.table_names');
+
+        if (empty($tableNames)) {
+            throw new \Exception('Error: config/permission.php not found and defaults could not be merged. Please publish the package configuration before proceeding, or drop the tables manually.');
+        }
+
+        Schema::drop($tableNames['role_has_permissions']);
+        Schema::drop($tableNames['model_has_roles']);
+        Schema::drop($tableNames['model_has_permissions']);
+        Schema::drop($tableNames['roles']);
+        Schema::drop($tableNames['permissions']);
+    }
+}

--- a/database/migrations/2020_10_28_095606_create_permission_tables.php
+++ b/database/migrations/2020_10_28_095606_create_permission_tables.php
@@ -46,8 +46,10 @@ class CreatePermissionTables extends Migration
                 ->on($tableNames['permissions'])
                 ->onDelete('cascade');
 
-            $table->primary(['permission_id', $columnNames['model_morph_key'], 'model_type'],
-                    'model_has_permissions_permission_model_type_primary');
+            $table->primary(
+                ['permission_id', $columnNames['model_morph_key'], 'model_type'],
+                'model_has_permissions_permission_model_type_primary'
+            );
         });
 
         Schema::create($tableNames['model_has_roles'], function (Blueprint $table) use ($tableNames, $columnNames) {
@@ -62,8 +64,10 @@ class CreatePermissionTables extends Migration
                 ->on($tableNames['roles'])
                 ->onDelete('cascade');
 
-            $table->primary(['role_id', $columnNames['model_morph_key'], 'model_type'],
-                    'model_has_roles_role_model_type_primary');
+            $table->primary(
+                ['role_id', $columnNames['model_morph_key'], 'model_type'],
+                'model_has_roles_role_model_type_primary'
+            );
         });
 
         Schema::create($tableNames['role_has_permissions'], function (Blueprint $table) use ($tableNames) {

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -13,11 +13,10 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        $this->call(
-            [
+        $this->call([
             UserSeeder::class,
-            GameSeeder::class
-            ]
-        );
+            GameSeeder::class,
+            RoleSeeder::class,
+        ]);
     }
 }

--- a/database/seeders/RoleSeeder.php
+++ b/database/seeders/RoleSeeder.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Spatie\Permission\Models\Role;
+
+class RoleSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        // create "admin" role, used for API requests
+        Role::create([
+            'name' => 'admin',
+            'guard_name' => 'api',
+        ]);
+    }
+}

--- a/docs/api.pbbg.com.yaml
+++ b/docs/api.pbbg.com.yaml
@@ -286,6 +286,16 @@ paths:
                   message:
                     type: "string"
                     example: "Unauthenticated."
+        403:
+          description: "authorization required"
+          content:
+            application/json:
+              schema:
+                type: "object"
+                properties:
+                  message:
+                    type: "string"
+                    example: "User does not have the right roles."
   /users/{userId}:
     get:
       tags:

--- a/docs/api.pbbg.com.yaml
+++ b/docs/api.pbbg.com.yaml
@@ -3,12 +3,12 @@ openapi: "3.0.0"
 info:
   title: "The PBBG API"
   description: "The API for Persistent Browser-Based Games."
-  version: "0.1.5"
+  version: "0.1.6"
 externalDocs:
   description: "Find out more about this project"
   url: "https://github.com/pbbg"
 servers:
-  - url: "https://virtserver.swaggerhub.com/pbbg/api.pbbg.com/0.1.5"
+  - url: "https://virtserver.swaggerhub.com/pbbg/api.pbbg.com/0.1.6"
     description: "SwaggerHub API Auto Mocking"
   - url: "https://dev-api.pbbg.com"
     description: "Development API"

--- a/docs/api.pbbg.com.yaml
+++ b/docs/api.pbbg.com.yaml
@@ -276,6 +276,16 @@ paths:
                       total:
                         type: "number"
                         example: 1
+        401:
+          description: "authentication required"
+          content:
+            application/json:
+              schema:
+                type: "object"
+                properties:
+                  data:
+                    type: "string"
+                    example: "Unauthenticated."
   /users/{userId}:
     get:
       tags:

--- a/docs/api.pbbg.com.yaml
+++ b/docs/api.pbbg.com.yaml
@@ -283,7 +283,7 @@ paths:
               schema:
                 type: "object"
                 properties:
-                  data:
+                  message:
                     type: "string"
                     example: "Unauthenticated."
   /users/{userId}:

--- a/routes/api.php
+++ b/routes/api.php
@@ -31,7 +31,7 @@ Route::middleware('auth:api')->get('/user', function (Request $request) {
 
 // users
 Route::get('/users', [UserController::class, 'index']);
-Route::delete('/users', [UserController::class, 'destroyAll'])->middleware('auth:api');
+Route::delete('/users', [UserController::class, 'destroyAll'])->middleware(['auth:api', 'role:admin']);
 Route::get('/users/{user_id}', [UserController::class, 'show']);
 
 // games

--- a/routes/api.php
+++ b/routes/api.php
@@ -31,7 +31,7 @@ Route::middleware('auth:api')->get('/user', function (Request $request) {
 
 // users
 Route::get('/users', [UserController::class, 'index']);
-Route::delete('/users', [UserController::class, 'destroyAll']);
+Route::delete('/users', [UserController::class, 'destroyAll'])->middleware('auth:api');
 Route::get('/users/{user_id}', [UserController::class, 'show']);
 
 // games

--- a/schemas/responses/403.json
+++ b/schemas/responses/403.json
@@ -1,0 +1,11 @@
+{
+    "type": "object",
+    "required": [
+        "message"
+    ],
+    "properties": {
+        "message": {
+            "type": "string"
+        }
+    }
+}

--- a/tests/Feature/Users/DeleteUsersTest.php
+++ b/tests/Feature/Users/DeleteUsersTest.php
@@ -5,12 +5,34 @@ namespace Tests\Feature;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\DB;
+use Spatie\Permission\Models\Role;
 use Tests\TestCase;
 
 class DeleteUsersTest extends TestCase
 {
     /**
-     * Get list of users
+     * Setup the test environment.
+     * Deletes existing roles and permissions before running a test.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        DB::statement('TRUNCATE TABLE model_has_roles;');
+
+        // turn off FK constraint to allow truncate
+        DB::statement('SET FOREIGN_KEY_CHECKS = 0;');
+        Role::truncate();
+        DB::statement('SET FOREIGN_KEY_CHECKS = 1;');
+
+        Role::create(['name' => 'admin']);
+    }
+
+    /**
+     * Tests that the authorized user can delete all users.
      *
      * @return void
      */
@@ -19,12 +41,38 @@ class DeleteUsersTest extends TestCase
         $this->registerUser();
 
         $count = User::count();
-        $this->assertGreaterThan(0,$count);
+        $this->assertGreaterThan(0, $count);
+
+        $user = User::create([
+            'name' => 'user_'.uniqid(),
+            'email' => 'test_'.uniqid().'@test.test',
+            'password' => encrypt('password'),
+        ]);
+
+        $this->actingAs($user);
 
         $response = $this->withHeaders(['Accept' => 'application/json'])->delete('/users');
+
         $this->assertResponse($response, 200);
 
         $count = User::count();
-        $this->assertEquals(0,$count);
+        $this->assertEquals(0, $count);
+    }
+
+    /**
+     * Tests that an unauthenticated user cannot delete all users.
+     *
+     * @return void
+     */
+    public function testDeleteUsersWithoutAuthentication()
+    {
+        $this->registerUser();
+
+        $count = User::count();
+        $this->assertGreaterThan(0, $count);
+
+        $response = $this->withHeaders(['Accept' => 'application/json'])->delete('/users');
+
+        $this->assertResponse($response, 401);
     }
 }

--- a/tests/Unit/AuthorizationTest.php
+++ b/tests/Unit/AuthorizationTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class AuthorizationTest extends TestCase
+{
+    /**
+     * Setup the test environment.
+     * Deletes existing roles and permissions before running a test.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        DB::statement('TRUNCATE TABLE role_has_permissions;');
+        DB::statement('TRUNCATE TABLE model_has_roles;');
+        DB::statement('TRUNCATE TABLE model_has_permissions;');
+
+        // turn off FK constraint to allow truncate
+        DB::statement('SET FOREIGN_KEY_CHECKS = 0;');
+        Role::truncate();
+        Permission::truncate();
+        DB::statement('SET FOREIGN_KEY_CHECKS = 1;');
+    }
+
+    /**
+     * Tests that the user has a role called "test_role".
+     *
+     */
+    public function testUserHasRole()
+    {
+        $user = User::create([
+            'name' => 'test_'.uniqid(),
+            'email' => 'test_'.uniqid().'@test.test',
+            'password' => bcrypt('password'),
+        ]);
+
+        $role = Role::create(['name' => 'test_role']);
+
+        $user->assignRole($role);
+
+        $this->assertCount(1, $user->roles);
+        $this->assertEquals('test_role', $user->roles->first()->name);
+    }
+
+    /**
+     * Tests that the user has a permission called "can pass test".
+     *
+     * @return void
+     */
+    public function testUserHasPermission()
+    {
+        $role = Role::create(['name' => 'role_'.uniqid()]);
+        $permission = Permission::create(['name' => 'can pass test']);
+
+        $role->givePermissionTo($permission);
+
+        $this->assertCount(1, $role->permissions);
+        $this->assertEquals('can pass test', $role->permissions->first()->name);
+    }
+}


### PR DESCRIPTION
This PR adds an administrator role to the application as per #22. The [spatie/laravel-permission](https://github.com/spatie/laravel-permission) package was used to provide the role and permission functionality.

- Role is generated using the `RoleSeeder` seeder
- Tests added to show functionality
- API documentation has been updated

This role is currently used to protect the delete all users route, which now also requires API authentication.