### PR TITLE
Disable rate limit outside of production

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -57,10 +57,10 @@ class RouteServiceProvider extends ServiceProvider
      */
     protected function configureRateLimiting()
     {
-        if (app()->environment('production')) {
-            RateLimiter::for('api', function () {
-                return Limit::perMinute(60);
-            });
-        }
+        RateLimiter::for('api', function () {
+            return (app()->environment('production'))
+                ? Limit::perMinute(60)
+                : Limit::none();
+        });
     }
 }

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -57,8 +57,10 @@ class RouteServiceProvider extends ServiceProvider
      */
     protected function configureRateLimiting()
     {
-        RateLimiter::for('api', function (Request $request) {
-            return Limit::perMinute(60);
-        });
+        if (app()->environment('production')) {
+            RateLimiter::for('api', function () {
+                return Limit::perMinute(60);
+            });
+        }
     }
 }


### PR DESCRIPTION
This PR addresses #30 by disabling API request rate limiting when the application environment is not set to production. This change has been made to ensure that the front-end UAT tests can run without any concern of rate limiting.