### PR TITLE
Tests refactor

### DIFF
--- a/app/Http/Controllers/FeedController.php
+++ b/app/Http/Controllers/FeedController.php
@@ -47,18 +47,15 @@ class FeedController extends Controller
 
         usort($feed_items, array(FeedController::class, 'sortByTimestamp'));
 
-        $feed_items = array_slice($feed_items, 0,6);
+        $feed_items = array_slice($feed_items, 0, 6);
 
         return [
             'data' => $feed_items
         ];
-
     }
 
-    private static function sortByTimestamp($a,$b) {
+    private static function sortByTimestamp($a, $b)
+    {
         return $b['timestamp'] - $a['timestamp'];
     }
-
-
-
 }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -70,7 +70,7 @@ class UserController extends Controller
     public function destroyAll()
     {
         # todo: this should be reserved for admins
-        User::truncate();
+        User::query()->delete();
         return UserResource::collection(User::paginate());
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -21,13 +21,13 @@
         <server name="APP_ENV" value="testing"/>
         <server name="BCRYPT_ROUNDS" value="4"/>
         <server name="CACHE_DRIVER" value="array"/>
-        <!-- <server name="DB_CONNECTION" value="sqlite"/> -->
-        <!-- <server name="DB_DATABASE" value=":memory:"/> -->
+        <server name="DB_CONNECTION" value="sqlite"/>
+        <server name="DB_DATABASE" value=":memory:"/>
         <server name="MAIL_MAILER" value="array"/>
         <server name="QUEUE_CONNECTION" value="sync"/>
         <server name="SESSION_DRIVER" value="array"/>
         <server name="TELESCOPE_ENABLED" value="false"/>
-        <server name="PASSPORT_PERSONAL_ACCESS_CLIENT_ID" value="1" />
-        <server name="PASSPORT_PERSONAL_ACCESS_CLIENT_SECRET" value="secret" />
+        <server name="PASSPORT_PERSONAL_ACCESS_CLIENT_ID" value="1"/>
+        <server name="PASSPORT_PERSONAL_ACCESS_CLIENT_SECRET" value="secret"/>
     </php>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -27,5 +27,7 @@
         <server name="QUEUE_CONNECTION" value="sync"/>
         <server name="SESSION_DRIVER" value="array"/>
         <server name="TELESCOPE_ENABLED" value="false"/>
+        <server name="PASSPORT_PERSONAL_ACCESS_CLIENT_ID" value="1" />
+        <server name="PASSPORT_PERSONAL_ACCESS_CLIENT_SECRET" value="secret" />
     </php>
 </phpunit>

--- a/tests/Feature/ApiTest.php
+++ b/tests/Feature/ApiTest.php
@@ -14,7 +14,6 @@ class ApiTest extends TestCase
     public function testApiRootResponse()
     {
         $response = $this->get('/');
-
         $response->assertStatus(200);
     }
 }

--- a/tests/Feature/ApiTest.php
+++ b/tests/Feature/ApiTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 class ApiTest extends TestCase

--- a/tests/Feature/Feeds/GetFeedsTest.php
+++ b/tests/Feature/Feeds/GetFeedsTest.php
@@ -7,7 +7,7 @@ use Tests\TestCase;
 class GetFeedsTest extends TestCase
 {
     /**
-     * Get list of games
+     * Get list of feeds
      *
      * @return void
      */

--- a/tests/Feature/Feeds/GetFeedsTest.php
+++ b/tests/Feature/Feeds/GetFeedsTest.php
@@ -14,7 +14,7 @@ class GetFeedsTest extends TestCase
     public function testGetFeeds()
     {
         $this->withoutExceptionHandling();
-        $response = $this->withHeaders(['Accept' => 'application/json'])->get('/feeds');
+        $response = $this->get('/feeds');
         $this->assertResponse($response, 200);
     }
 }

--- a/tests/Feature/Feeds/GetFeedsTest.php
+++ b/tests/Feature/Feeds/GetFeedsTest.php
@@ -1,9 +1,7 @@
 <?php
 
-namespace Tests\Feature;
+namespace Tests\Feature\Feeds;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 
 class GetFeedsTest extends TestCase

--- a/tests/Feature/Games/GetGameTest.php
+++ b/tests/Feature/Games/GetGameTest.php
@@ -1,9 +1,7 @@
 <?php
 
-namespace Tests\Feature;
+namespace Tests\Feature\Games;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 
 class GetGameTest extends TestCase

--- a/tests/Feature/Games/GetGamesTest.php
+++ b/tests/Feature/Games/GetGamesTest.php
@@ -13,10 +13,7 @@ class GetGamesTest extends TestCase
      */
     public function testGetGames()
     {
-        $response = $this->withHeaders([
-            'Accept' => 'application/json'
-        ])->get('/games');
-
+        $response = $this->get('/games');
         $this->assertResponse($response, 200);
     }
 }

--- a/tests/Feature/Games/GetGamesTest.php
+++ b/tests/Feature/Games/GetGamesTest.php
@@ -13,7 +13,10 @@ class GetGamesTest extends TestCase
      */
     public function testGetGames()
     {
-        $response = $this->withHeaders(['Accept' => 'application/json'])->get('/games');
+        $response = $this->withHeaders([
+            'Accept' => 'application/json'
+        ])->get('/games');
+
         $this->assertResponse($response, 200);
     }
 }

--- a/tests/Feature/Games/GetGamesTest.php
+++ b/tests/Feature/Games/GetGamesTest.php
@@ -1,9 +1,7 @@
 <?php
 
-namespace Tests\Feature;
+namespace Tests\Feature\Games;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 
 class GetGamesTest extends TestCase

--- a/tests/Feature/Games/PostGamesTest.php
+++ b/tests/Feature/Games/PostGamesTest.php
@@ -19,7 +19,10 @@ class PostGamesTest extends TestCase
      */
     public function testPostGamesWithUnauthenticatedUser()
     {
-        $post_response = $this->withHeaders(['Accept' => 'application/json'])->post('/games');
+        $post_response = $this->withHeaders([
+            'Accept' => 'application/json'
+        ])->post('/games');
+
         $this->assertNotEquals(403, $post_response->getStatusCode());
     }
 
@@ -31,9 +34,11 @@ class PostGamesTest extends TestCase
     public function testPostGamesWithAuthenticatedUser()
     {
         Passport::actingAs(User::factory()->create());
+
         $post_response = $this->withHeaders([
             'Accept' => 'application/json',
         ])->post('/games');
+
         $this->assertNotEquals(403, $post_response->getStatusCode());
     }
 

--- a/tests/Feature/Games/PostGamesTest.php
+++ b/tests/Feature/Games/PostGamesTest.php
@@ -19,11 +19,8 @@ class PostGamesTest extends TestCase
      */
     public function testPostGamesWithUnauthenticatedUser()
     {
-        $post_response = $this->withHeaders([
-            'Accept' => 'application/json'
-        ])->post('/games');
-
-        $this->assertNotEquals(403, $post_response->getStatusCode());
+        $response = $this->post('/games');
+        $this->assertNotEquals(403, $response->getStatusCode());
     }
 
     /**
@@ -35,11 +32,8 @@ class PostGamesTest extends TestCase
     {
         Passport::actingAs(User::factory()->create());
 
-        $post_response = $this->withHeaders([
-            'Accept' => 'application/json',
-        ])->post('/games');
-
-        $this->assertNotEquals(403, $post_response->getStatusCode());
+        $response = $this->post('/games');
+        $this->assertNotEquals(403, $response->getStatusCode());
     }
 
     /**
@@ -49,9 +43,7 @@ class PostGamesTest extends TestCase
      */
     public function testPostGamesWithCorrectInput()
     {
-        $response = $this->withHeaders([
-            'Accept' => 'application/json',
-        ])->post('/games', [
+        $response = $this->post('/games', [
             'name' => $this->faker->name,
             'url' => $this->faker->unique()->url,
             'short_description' => $this->faker->text($maxNbChars = 140),
@@ -74,9 +66,7 @@ class PostGamesTest extends TestCase
     {
         $input_game = Game::factory()->create();
 
-        $response = $this->withHeaders([
-            'Accept' => 'application/json',
-        ])->post('/games', [
+        $response = $this->post('/games', [
             'name' => 'some ! bad @ characters # to $ test %',
             'url' => 'not_a_url',
             'short_description' => $input_game->long_description,
@@ -97,10 +87,7 @@ class PostGamesTest extends TestCase
      */
     public function testPostGamesWithEmptyInput()
     {
-        $response = $this->withHeaders([
-            'Accept' => 'application/json',
-        ])->post('/games');
-
+        $response = $this->post('/games');
         $this->assertResponse($response, 422);
     }
 }

--- a/tests/Feature/Games/PostGamesTest.php
+++ b/tests/Feature/Games/PostGamesTest.php
@@ -3,7 +3,9 @@
 namespace Tests\Feature\Games;
 
 use App\Models\Game;
+use App\Models\User;
 use Illuminate\Foundation\Testing\WithFaker;
+use Laravel\Passport\Passport;
 use Tests\TestCase;
 
 class PostGamesTest extends TestCase
@@ -28,10 +30,9 @@ class PostGamesTest extends TestCase
      */
     public function testPostGamesWithAuthenticatedUser()
     {
-        $token = $this->registerUser();
+        Passport::actingAs(User::factory()->create());
         $post_response = $this->withHeaders([
             'Accept' => 'application/json',
-            'Authorization' => "Bearer $token"
         ])->post('/games');
         $this->assertNotEquals(403, $post_response->getStatusCode());
     }

--- a/tests/Feature/Games/PostGamesTest.php
+++ b/tests/Feature/Games/PostGamesTest.php
@@ -1,9 +1,8 @@
 <?php
 
-namespace Tests\Feature;
+namespace Tests\Feature\Games;
 
 use App\Models\Game;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 

--- a/tests/Feature/Users/DeleteUsersTest.php
+++ b/tests/Feature/Users/DeleteUsersTest.php
@@ -27,7 +27,9 @@ class DeleteUsersTest extends TestCase
 
         Passport::actingAs($user);
 
-        $response = $this->withHeaders(['Accept' => 'application/json'])->delete('/users');
+        $response = $this->withHeaders([
+            'Accept' => 'application/json'
+        ])->delete('/users');
 
         $this->assertResponse($response, 200);
 
@@ -47,7 +49,9 @@ class DeleteUsersTest extends TestCase
         $count = User::count();
         $this->assertGreaterThan(0, $count);
 
-        $response = $this->withHeaders(['Accept' => 'application/json'])->delete('/users');
+        $response = $this->withHeaders([
+            'Accept' => 'application/json'
+        ])->delete('/users');
 
         $this->assertResponse($response, 403);
     }
@@ -60,10 +64,11 @@ class DeleteUsersTest extends TestCase
     public function testDeleteUsersWithoutAuthentication()
     {
         $count = User::count();
-
         $this->assertGreaterThan(0, $count);
 
-        $response = $this->withHeaders(['Accept' => 'application/json'])->delete('/users');
+        $response = $this->withHeaders([
+            'Accept' => 'application/json'
+        ])->delete('/users');
 
         $this->assertResponse($response, 401);
     }

--- a/tests/Feature/Users/DeleteUsersTest.php
+++ b/tests/Feature/Users/DeleteUsersTest.php
@@ -1,10 +1,8 @@
 <?php
 
-namespace Tests\Feature;
+namespace Tests\Feature\Users;
 
 use App\Models\User;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Facades\DB;
 use Spatie\Permission\Models\Role;
 use Tests\TestCase;

--- a/tests/Feature/Users/DeleteUsersTest.php
+++ b/tests/Feature/Users/DeleteUsersTest.php
@@ -3,34 +3,12 @@
 namespace Tests\Feature\Users;
 
 use App\Models\User;
-use Illuminate\Support\Facades\DB;
 use Laravel\Passport\Passport;
 use Spatie\Permission\Models\Role;
 use Tests\TestCase;
 
 class DeleteUsersTest extends TestCase
 {
-    /**
-     * Setup the test environment.
-     * Deletes existing roles and permissions before running a test.
-     *
-     * @return void
-     */
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        DB::statement('TRUNCATE TABLE model_has_roles;');
-
-        // turn off FK constraint to allow truncate
-        DB::statement('SET FOREIGN_KEY_CHECKS = 0;');
-        Role::truncate();
-        DB::statement('SET FOREIGN_KEY_CHECKS = 1;');
-
-        // create role
-        Role::create(['name' => 'admin']);
-    }
-
     /**
      * Tests that the authorized user can delete all users.
      *
@@ -82,6 +60,7 @@ class DeleteUsersTest extends TestCase
     public function testDeleteUsersWithoutAuthentication()
     {
         $count = User::count();
+
         $this->assertGreaterThan(0, $count);
 
         $response = $this->withHeaders(['Accept' => 'application/json'])->delete('/users');

--- a/tests/Feature/Users/DeleteUsersTest.php
+++ b/tests/Feature/Users/DeleteUsersTest.php
@@ -27,9 +27,7 @@ class DeleteUsersTest extends TestCase
 
         Passport::actingAs($user);
 
-        $response = $this->withHeaders([
-            'Accept' => 'application/json'
-        ])->delete('/users');
+        $response = $this->delete('/users');
 
         $this->assertResponse($response, 200);
 
@@ -49,10 +47,7 @@ class DeleteUsersTest extends TestCase
         $count = User::count();
         $this->assertGreaterThan(0, $count);
 
-        $response = $this->withHeaders([
-            'Accept' => 'application/json'
-        ])->delete('/users');
-
+        $response = $this->delete('/users');
         $this->assertResponse($response, 403);
     }
 
@@ -66,10 +61,7 @@ class DeleteUsersTest extends TestCase
         $count = User::count();
         $this->assertGreaterThan(0, $count);
 
-        $response = $this->withHeaders([
-            'Accept' => 'application/json'
-        ])->delete('/users');
-
+        $response = $this->delete('/users');
         $this->assertResponse($response, 401);
     }
 }

--- a/tests/Feature/Users/DeleteUsersTest.php
+++ b/tests/Feature/Users/DeleteUsersTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Users;
 
 use App\Models\User;
 use Illuminate\Support\Facades\DB;
+use Laravel\Passport\Passport;
 use Spatie\Permission\Models\Role;
 use Tests\TestCase;
 
@@ -37,21 +38,16 @@ class DeleteUsersTest extends TestCase
      */
     public function testDeleteUsers()
     {
-        $this->registerUser();
+        $user = User::factory()->create();
 
         $count = User::count();
         $this->assertGreaterThan(0, $count);
 
-        $user = User::create([
-            'name' => 'user_'.uniqid(),
-            'email' => 'test_'.uniqid().'@test.test',
-            'password' => encrypt('password'),
-        ]);
-
         $role = Role::where('name', 'admin')->first();
 
         $user->assignRole($role);
-        $this->actingAs($user);
+
+        Passport::actingAs($user);
 
         $response = $this->withHeaders(['Accept' => 'application/json'])->delete('/users');
 
@@ -68,18 +64,10 @@ class DeleteUsersTest extends TestCase
      */
     public function testDeleteUsersWithoutAuthorization()
     {
-        $this->registerUser();
+        Passport::actingAs(User::factory()->create());
 
         $count = User::count();
         $this->assertGreaterThan(0, $count);
-
-        $user = User::create([
-            'name' => 'user_'.uniqid(),
-            'email' => 'test_'.uniqid().'@test.test',
-            'password' => encrypt('password'),
-        ]);
-
-        $this->actingAs($user);
 
         $response = $this->withHeaders(['Accept' => 'application/json'])->delete('/users');
 
@@ -93,8 +81,6 @@ class DeleteUsersTest extends TestCase
      */
     public function testDeleteUsersWithoutAuthentication()
     {
-        $this->registerUser();
-
         $count = User::count();
         $this->assertGreaterThan(0, $count);
 

--- a/tests/Feature/Users/GetAuthenticatedUserTest.php
+++ b/tests/Feature/Users/GetAuthenticatedUserTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Feature\Users;
 
+use App\Models\User;
+use Laravel\Passport\Passport;
 use Tests\TestCase;
 
 class GetAuthenticatedUserTest extends TestCase
@@ -13,10 +15,9 @@ class GetAuthenticatedUserTest extends TestCase
      */
     public function testAnAuthenticatedUserCanAccessAuthenticatedUserData()
     {
-        $token = $this->registerUser();
+        Passport::actingAs(User::factory()->create());
         $response = $this->withHeaders([
             'Accept' => 'application/json',
-            'Authorization' => "Bearer $token"
         ])->get('/user');
         $this->assertResponse($response, 200);
     }

--- a/tests/Feature/Users/GetAuthenticatedUserTest.php
+++ b/tests/Feature/Users/GetAuthenticatedUserTest.php
@@ -17,10 +17,7 @@ class GetAuthenticatedUserTest extends TestCase
     {
         Passport::actingAs(User::factory()->create());
 
-        $response = $this->withHeaders([
-            'Accept' => 'application/json',
-        ])->get('/user');
-
+        $response = $this->get('/user');
         $this->assertResponse($response, 200);
     }
 
@@ -32,8 +29,7 @@ class GetAuthenticatedUserTest extends TestCase
     public function testAnUnauthenticatedUserCanNotAccessAuthenticatedUserData()
     {
         $response = $this->withHeaders([
-            'Accept' => 'application/json',
-            'Authorization' => "Bearer InvalidToken"
+            'Authorization' => "Bearer InvalidToken",
         ])->get('/user');
 
         $this->assertResponse($response, 401);

--- a/tests/Feature/Users/GetAuthenticatedUserTest.php
+++ b/tests/Feature/Users/GetAuthenticatedUserTest.php
@@ -1,9 +1,7 @@
 <?php
 
-namespace Tests\Feature;
+namespace Tests\Feature\Users;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 
 class GetAuthenticatedUserTest extends TestCase

--- a/tests/Feature/Users/GetAuthenticatedUserTest.php
+++ b/tests/Feature/Users/GetAuthenticatedUserTest.php
@@ -16,9 +16,11 @@ class GetAuthenticatedUserTest extends TestCase
     public function testAnAuthenticatedUserCanAccessAuthenticatedUserData()
     {
         Passport::actingAs(User::factory()->create());
+
         $response = $this->withHeaders([
             'Accept' => 'application/json',
         ])->get('/user');
+
         $this->assertResponse($response, 200);
     }
 
@@ -33,6 +35,7 @@ class GetAuthenticatedUserTest extends TestCase
             'Accept' => 'application/json',
             'Authorization' => "Bearer InvalidToken"
         ])->get('/user');
+
         $this->assertResponse($response, 401);
     }
 

--- a/tests/Feature/Users/GetUserTest.php
+++ b/tests/Feature/Users/GetUserTest.php
@@ -1,9 +1,7 @@
 <?php
 
-namespace Tests\Feature;
+namespace Tests\Feature\Users;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 
 class GetUserTest extends TestCase

--- a/tests/Feature/Users/GetUsersTest.php
+++ b/tests/Feature/Users/GetUsersTest.php
@@ -1,9 +1,7 @@
 <?php
 
-namespace Tests\Feature;
+namespace Tests\Feature\Users;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 
 class GetUsersTest extends TestCase

--- a/tests/Feature/Users/GetUsersTest.php
+++ b/tests/Feature/Users/GetUsersTest.php
@@ -13,7 +13,10 @@ class GetUsersTest extends TestCase
      */
     public function testGetUsers()
     {
-        $response = $this->withHeaders(['Accept' => 'application/json'])->get('/users');
+        $response = $this->withHeaders([
+            'Accept' => 'application/json'
+        ])->get('/users');
+
         $this->assertResponse($response, 200);
     }
 }

--- a/tests/Feature/Users/GetUsersTest.php
+++ b/tests/Feature/Users/GetUsersTest.php
@@ -13,10 +13,7 @@ class GetUsersTest extends TestCase
      */
     public function testGetUsers()
     {
-        $response = $this->withHeaders([
-            'Accept' => 'application/json'
-        ])->get('/users');
-
+        $response = $this->get('/users');
         $this->assertResponse($response, 200);
     }
 }

--- a/tests/Feature/Users/PostLoginTest.php
+++ b/tests/Feature/Users/PostLoginTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Feature\Users;
 
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
 use Tests\TestCase;
 
 class PostLoginTest extends TestCase
@@ -13,13 +15,14 @@ class PostLoginTest extends TestCase
      */
     public function testPostLogInWithValidCredentials()
     {
-        $uuid = uniqid();
-        $this->registerUser($uuid);
+        $user = User::factory()->create([
+            'password' => Hash::make($password = 'password'),
+        ]);
         $response = $this->withHeaders([
             'Accept' => 'application/json',
         ])->post('/login', [
-            'email' => 'foo_' . $uuid . '@bar.baz',
-            'password' => 'foobarbaz',
+            'email' => $user->email,
+            'password' => $password,
         ]);
         $this->assertResponse($response, 200);
     }
@@ -31,12 +34,10 @@ class PostLoginTest extends TestCase
      */
     public function testPostLogInWithInvalidCredentials()
     {
-        $uuid = uniqid();
-        $this->registerUser($uuid);
         $response = $this->withHeaders([
             'Accept' => 'application/json',
         ])->post('/login', [
-            'email' => 'foo_' . $uuid . '@bar.baz',
+            'email' => 'foo_' . uniqid() . '@bar.baz',
             'password' => 'incorrectpassword'
         ]);
         $this->assertResponse($response, 401);

--- a/tests/Feature/Users/PostLoginTest.php
+++ b/tests/Feature/Users/PostLoginTest.php
@@ -1,9 +1,7 @@
 <?php
 
-namespace Tests\Feature;
+namespace Tests\Feature\Users;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 
 class PostLoginTest extends TestCase

--- a/tests/Feature/Users/PostLoginTest.php
+++ b/tests/Feature/Users/PostLoginTest.php
@@ -18,12 +18,14 @@ class PostLoginTest extends TestCase
         $user = User::factory()->create([
             'password' => Hash::make($password = 'password'),
         ]);
+
         $response = $this->withHeaders([
             'Accept' => 'application/json',
         ])->post('/login', [
             'email' => $user->email,
             'password' => $password,
         ]);
+
         $this->assertResponse($response, 200);
     }
 

--- a/tests/Feature/Users/PostLoginTest.php
+++ b/tests/Feature/Users/PostLoginTest.php
@@ -19,9 +19,7 @@ class PostLoginTest extends TestCase
             'password' => Hash::make($password = 'password'),
         ]);
 
-        $response = $this->withHeaders([
-            'Accept' => 'application/json',
-        ])->post('/login', [
+        $response = $this->post('/login', [
             'email' => $user->email,
             'password' => $password,
         ]);

--- a/tests/Feature/Users/PostRegisterTest.php
+++ b/tests/Feature/Users/PostRegisterTest.php
@@ -1,9 +1,7 @@
 <?php
 
-namespace Tests\Feature;
+namespace Tests\Feature\Users;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 
 class PostRegisterTest extends TestCase

--- a/tests/Feature/Users/PostRegisterTest.php
+++ b/tests/Feature/Users/PostRegisterTest.php
@@ -13,9 +13,7 @@ class PostRegisterTest extends TestCase
      */
     public function testPostRegisterWithCorrectInput()
     {
-        $response = $this->withHeaders([
-            'Accept' => 'application/json',
-        ])->post('/register', [
+        $response = $this->post('/register', [
             'name' => 'User_' . uniqid(),
             'email' => 'foo_' . uniqid() . '@bar.baz',
             'password' => 'foobarbaz'
@@ -31,9 +29,7 @@ class PostRegisterTest extends TestCase
      */
     public function testPostRegisterWithIncorrectInput()
     {
-        $response = $this->withHeaders([
-            'Accept' => 'application/json',
-        ])->post('/register', [
+        $response = $this->post('/register', [
             'name' => 'User_' . uniqid(),
             'email' => 'foo_' . uniqid() . '@bar.baz',
             'password' => 'foobar'
@@ -49,10 +45,7 @@ class PostRegisterTest extends TestCase
      */
     public function testPostRegisterWithEmptyInput()
     {
-        $response = $this->withHeaders([
-            'Accept' => 'application/json',
-        ])->post('/register');
-
+        $response = $this->post('/register');
         $this->assertResponse($response, 422);
     }
 }

--- a/tests/Feature/Users/PostRegisterTest.php
+++ b/tests/Feature/Users/PostRegisterTest.php
@@ -13,14 +13,14 @@ class PostRegisterTest extends TestCase
      */
     public function testPostRegisterWithCorrectInput()
     {
-        $random_uuid = uniqid();
         $response = $this->withHeaders([
             'Accept' => 'application/json',
         ])->post('/register', [
-            'name' => 'User_' . $random_uuid,
-            'email' => 'foo_' . $random_uuid . '@bar.baz',
+            'name' => 'User_' . uniqid(),
+            'email' => 'foo_' . uniqid() . '@bar.baz',
             'password' => 'foobarbaz'
         ]);
+
         $this->assertResponse($response, 200);
     }
 
@@ -31,12 +31,11 @@ class PostRegisterTest extends TestCase
      */
     public function testPostRegisterWithIncorrectInput()
     {
-        $random_uuid = uniqid();
         $response = $this->withHeaders([
             'Accept' => 'application/json',
         ])->post('/register', [
-            'name' => 'User_' . $random_uuid,
-            'email' => 'foo_' . $random_uuid . '@bar.baz',
+            'name' => 'User_' . uniqid(),
+            'email' => 'foo_' . uniqid() . '@bar.baz',
             'password' => 'foobar'
         ]);
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,28 +10,6 @@ abstract class TestCase extends BaseTestCase
     use CreatesApplication;
 
     /**
-     * Register a new user and return its corresponding API token.
-     *
-     * @param null $uuid
-     * @return mixed
-     */
-    protected function registerUser($uuid = null)
-    {
-        $uuid = $uuid ?: uniqid();
-        $response = $this->withHeaders([
-            'Accept' => 'application/json',
-        ])->post('/register', [
-            'name' => 'User_' . $uuid,
-            'email' => 'foo_' . $uuid . '@bar.baz',
-            'password' => 'foobarbaz'
-        ]);
-        $response_json = json_decode($response->content());
-        $token = $response_json->data->token;
-        $this->assertNotEquals('', $token); # improve this to check that token is valid JWT
-        return $token;
-    }
-
-    /**
      * Assert that the schema of the response matches the defined schema.
      *
      * @param $data

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -21,6 +21,15 @@ abstract class TestCase extends BaseTestCase
     public $seed = true;
 
     /**
+     * The default headers sent when making requests.
+     *
+     * @var array<string, string>
+     */
+    protected $defaultHeaders = [
+        'Accept' => 'application/json',
+    ];
+
+    /**
      * Setup the test environment.
      *
      * @return void

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -9,7 +9,14 @@ abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
 
-    protected function registerUser($uuid = null) {
+    /**
+     * Register a new user and return its corresponding API token.
+     *
+     * @param null $uuid
+     * @return mixed
+     */
+    protected function registerUser($uuid = null)
+    {
         $uuid = $uuid ?: uniqid();
         $response = $this->withHeaders([
             'Accept' => 'application/json',
@@ -24,7 +31,14 @@ abstract class TestCase extends BaseTestCase
         return $token;
     }
 
-    public function assertSchema($data, $schema_file) {
+    /**
+     * Assert that the schema of the response matches the defined schema.
+     *
+     * @param $data
+     * @param $schema_file
+     */
+    public function assertSchema($data, $schema_file)
+    {
         $schema = Schema::fromJsonString(file_get_contents(__DIR__ . "/../schemas/$schema_file"));
         $validator = new Validator();
         $result = $validator->schemaValidation($data, $schema);
@@ -40,7 +54,14 @@ abstract class TestCase extends BaseTestCase
         $this->assertEquals(1, $result_is_valid);
     }
 
-    public function assertResponse($response, $code) {
+    /**
+     * Assert that the response has the correct code and schema expected.
+     *
+     * @param $response
+     * @param $code
+     */
+    public function assertResponse($response, $code)
+    {
         $response->assertStatus($code);
         $content = json_decode($response->getContent());
         $this->assertSchema($content, "responses/$code.json");

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,12 +2,64 @@
 
 namespace Tests;
 
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use Illuminate\Support\Facades\DB;
+use Laravel\Passport\ClientRepository;
 use Opis\JsonSchema\{Validator, Schema};
 
 abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
+    use RefreshDatabase;
+
+    /**
+     * Determines if database seeds should be executed after migration.
+     *
+     * @var bool
+     */
+    public $seed = true;
+
+    /**
+     * Setup the test environment.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (! file_exists(storage_path('oauth-private.key'))
+            || ! file_exists(storage_path('oauth-public.key'))
+        ) {
+            exit("Error: Install Laravel Passport\n");
+        }
+
+        $this->createTestClient();
+    }
+
+    /**
+     * Create a test personal access client for the application.
+     * The client ID and secret match credentials defined in "phpunit.xml".
+     *
+     * @return void
+     */
+    protected function createTestClient(): void
+    {
+        $client = app(ClientRepository::class)->createPersonalAccessClient(
+            null, 'Test Personal Access Client', 'http://localhost'
+        );
+
+        $client->id = 1;
+        $client->setSecretAttribute('secret');
+        $client->save();
+
+        DB::table('oauth_personal_access_clients')->insert([
+            'client_id'  => $client->id,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
 
     /**
      * Assert that the schema of the response matches the defined schema.

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,9 +3,7 @@
 namespace Tests;
 
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
-use Opis\JsonSchema\{
-    Validator, ValidationResult, ValidationError, Schema
-};
+use Opis\JsonSchema\{Validator, Schema};
 
 abstract class TestCase extends BaseTestCase
 {

--- a/tests/Unit/AuthorizationTest.php
+++ b/tests/Unit/AuthorizationTest.php
@@ -17,7 +17,6 @@ class AuthorizationTest extends TestCase
     public function testUserHasRole()
     {
         $user = User::factory()->create();
-
         $role = Role::create(['name' => 'test_role']);
 
         $user->assignRole($role);

--- a/tests/Unit/AuthorizationTest.php
+++ b/tests/Unit/AuthorizationTest.php
@@ -38,11 +38,7 @@ class AuthorizationTest extends TestCase
      */
     public function testUserHasRole()
     {
-        $user = User::create([
-            'name' => 'test_'.uniqid(),
-            'email' => 'test_'.uniqid().'@test.test',
-            'password' => bcrypt('password'),
-        ]);
+        $user = User::factory()->create();
 
         $role = Role::create(['name' => 'test_role']);
 

--- a/tests/Unit/AuthorizationTest.php
+++ b/tests/Unit/AuthorizationTest.php
@@ -34,6 +34,7 @@ class AuthorizationTest extends TestCase
     /**
      * Tests that the user has a role called "test_role".
      *
+     * @return void
      */
     public function testUserHasRole()
     {

--- a/tests/Unit/AuthorizationTest.php
+++ b/tests/Unit/AuthorizationTest.php
@@ -3,34 +3,12 @@
 namespace Tests\Unit;
 
 use App\Models\User;
-use Illuminate\Support\Facades\DB;
 use Spatie\Permission\Models\Permission;
 use Spatie\Permission\Models\Role;
 use Tests\TestCase;
 
 class AuthorizationTest extends TestCase
 {
-    /**
-     * Setup the test environment.
-     * Deletes existing roles and permissions before running a test.
-     *
-     * @return void
-     */
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        DB::statement('TRUNCATE TABLE role_has_permissions;');
-        DB::statement('TRUNCATE TABLE model_has_roles;');
-        DB::statement('TRUNCATE TABLE model_has_permissions;');
-
-        // turn off FK constraint to allow truncate
-        DB::statement('SET FOREIGN_KEY_CHECKS = 0;');
-        Role::truncate();
-        Permission::truncate();
-        DB::statement('SET FOREIGN_KEY_CHECKS = 1;');
-    }
-
     /**
      * Tests that the user has a role called "test_role".
      *


### PR DESCRIPTION
This PR refactors the test environment, consisting of additions to improve automation and QoL changes to make writing tests easier.

- Runs migrations and seeds before each test
- Generates a valid personal access token before each test. Paves the way to support GitHub Actions #3 
- Passport auth used where necessary, automatically passes the authorization token header
- Automatically set "Accept" HTTP header to expect JSON
- Tests conducted using an in-memory SQLite database. Addresses #18 
- User factory calls replace registerUser helper, no need to make an API call to create test users
- Missing test descriptions added
- Formatting fixes, applies style fixes and PSR-4 namespaces (required for Composer 2.0)