### PR TITLE
Fix CI build failure on app setup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.0
       - name: App Setup
         run: |
           cp .env.ci .env

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     ],
     "license": "GNU GPL v3.0",
     "require": {
-        "php": "^7.3",
+        "php": "^7.3|^8.0",
         "algolia/algoliasearch-client-php": "^2.7",
         "fideloper/proxy": "^4.2",
         "fruitcake/laravel-cors": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c7559d11b38141bf16cdcce566217cd3",
+    "content-hash": "580b73009168889e7bee861044e494d3",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",
@@ -6515,26 +6515,27 @@
         },
         {
             "name": "fzaninotto/faker",
-            "version": "v1.9.2",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/fzaninotto/Faker.git",
-                "reference": "848d8125239d7dbf8ab25cb7f054f1a630e68c2e"
+                "reference": "5ffe7db6c80f441f150fc88008d64e64af66634b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/848d8125239d7dbf8ab25cb7f054f1a630e68c2e",
-                "reference": "848d8125239d7dbf8ab25cb7f054f1a630e68c2e",
+                "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/5ffe7db6c80f441f150fc88008d64e64af66634b",
+                "reference": "5ffe7db6c80f441f150fc88008d64e64af66634b",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^5.3.3 || ^7.0 || ^8.0"
             },
             "require-dev": {
                 "ext-intl": "*",
                 "phpunit/phpunit": "^4.8.35 || ^5.7",
                 "squizlabs/php_codesniffer": "^2.9.2"
             },
+            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -6563,10 +6564,10 @@
             ],
             "support": {
                 "issues": "https://github.com/fzaninotto/Faker/issues",
-                "source": "https://github.com/fzaninotto/Faker/tree/v1.9.2"
+                "source": "https://github.com/fzaninotto/Faker/tree/master"
             },
             "abandoned": true,
-            "time": "2020-12-11T09:56:16+00:00"
+            "time": "2020-12-11T09:59:14+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -8906,7 +8907,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.3"
+        "php": "^7.3|^8.0"
     },
     "platform-dev": {
         "ext-json": "*"


### PR DESCRIPTION
This PR addresses #37 by fixing the CI pipeline, which was failing when trying to install the project's composer dependencies. The project composer.json did not allow PHP 8 to be used, which happens to be the default PHP version used by the "ubuntu-latest" image.

I have added an additional CI build step which allows for a specified PHP version to be used. I have set this default version to PHP 8, as the project does support it with all dependencies updated. Here is a link to a CI build with [all tests passing](https://github.com/mink/api.pbbg.com/runs/1827993828?check_suite_focus=true) on PHP 8.